### PR TITLE
git comand setting in admin setting menu.

### DIFF
--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -28,11 +28,15 @@ class Plugin extends gitbucket.core.plugin.Plugin {
   override val repositoryMenus = Seq(
     (repository: RepositoryInfo, context: Context) =>
       Some(Link(
-        id = "CommitGraphs",
-        label = "Commit Graphs",
-        path = s"/graphs",
+        id = pluginId,
+        label = pluginName,
+        path = s"/commitgraphs",
         icon = Some("menu-icon octicon octicon-graph")
       ))
+  )
+
+  override val systemSettingMenus: Seq[(Context) => Option[Link]] = Seq(
+    (ctx: Context) => Some(Link("Commit Graph","Commit Graph","admin/commitgraphs"))
   )
 
 }

--- a/src/main/scala/me/huzi/gitbucket/commitgraphs/controller/CommitGraphsController.scala
+++ b/src/main/scala/me/huzi/gitbucket/commitgraphs/controller/CommitGraphsController.scala
@@ -7,73 +7,122 @@ import gitbucket.core.controller._
 import gitbucket.core.model._
 import gitbucket.core.service._
 import gitbucket.core.util._
+import gitbucket.core.util.AdminAuthenticator
 import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Directory._
 import gitbucket.core.util.Implicits._
 import gitbucket.core.util.JGitUtil._
+import io.github.gitbucket.scalatra.forms._
+import me.huzi.gitbucket.commitgraphs.service.CommitGraphsSettingsService
+import me.huzi.gitbucket.commitgraphs.service.CommitGraphsSettingsService._
 import me.huzi.gitbucket.commitgraphs.html
 
 class CommitGraphsController extends CommitGraphsControllerBase
   with RepositoryService with AccountService
-  with ReferrerAuthenticator
+  with ReferrerAuthenticator with AdminAuthenticator
+  with CommitGraphsSettingsService
 
 trait CommitGraphsControllerBase extends ControllerBase {
-  self: RepositoryService with AccountService with ReferrerAuthenticator =>
+  self: RepositoryService with AccountService with ReferrerAuthenticator with AdminAuthenticator with CommitGraphsSettingsService =>
 
-  get("/:owner/:repository/graphs")(referrersOnly { repository =>
+  val settingsForm: MappingValueType[CommitGraphsSettings] = mapping(
+    "commitGraphsGitCommand"   -> text(required, maxlength(200)),
+    "action" -> text(required, maxlength(10))
+  )(CommitGraphsSettings.apply)
+
+  get("/admin/commitgraphs")(adminOnly {
+      val settings = loadCommitGraphsSettings()
+      html.settings(settings.CommitGraphsGitCommand, None)
+    }
+  )
+
+  post("/admin/commitgraphs", settingsForm)(adminOnly { form =>
+    assert(form.CommitGraphsGitCommand != null)
+    assert(!form.CommitGraphsGitCommand.isEmpty)
+    form.action match {
+      case "apply" =>
+        saveCommitGraphsSettings(form)
+        html.settings(form.CommitGraphsGitCommand, Some("Settings Saved"))
+      case _ =>
+        if( checkGitCommand(form.CommitGraphsGitCommand) ) {
+          html.settings(form.CommitGraphsGitCommand, Some("command check succeded"))
+        } else {
+          html.settings(form.CommitGraphsGitCommand, Some("no such command in path"))
+        }
+    }
+  })
+
+  get("/:owner/:repository/commitgraphs")(referrersOnly { repository =>
     using(Git.open(getRepositoryDir(repository.owner, repository.name))) { git =>
       if (JGitUtil.isEmpty(git)) {
         html.guide(repository)
       } else {
-        val commitGraphs = git.log.all.call.iterator.asScala.map { rev =>
-          val p = Process.apply(Seq("git", "log", "-n", "1", "--numstat", """--pretty="%H"""", "--source", rev.getId.name), git.getRepository.getDirectory)
-          val (additions, deletions) = p.lineStream_!.filter(_.split("\t").length == 3).foldLeft((0, 0)) { (i, l) =>
-            val Array(a, d, filename) = l.split("\t")
-            a.forall(_.isDigit) && d.forall(_.isDigit) match {
-              case true => (i._1 + a.toInt, i._2 + d.toInt)
-              case _    => i
-            }
-          }
-          CommitCount(
-            commit = new CommitInfo(rev),
-            additions = additions,
-            deletions = deletions)
-        }.toSeq.groupBy { x =>
-          if (x.commit.isDifferentFromAuthor) (x.commit.committerName, x.commit.committerEmailAddress)
-          else (x.commit.authorName, x.commit.authorEmailAddress)
-        }.toSeq.sortWith((lt1, lt2) => lt1._2.lengthCompare(lt2._2.length) > 0).map {
-          case ((userName, mailAddress), ds) =>
-            val dailys = ds.groupBy(x => date2DateStr(x.commit.authorTime)).map {
-              case (date, ds) =>
-                val (additions, deletions) = ds.foldLeft((0L, 0L)) { (i, d) =>
-                  (i._1 + d.additions, i._2 + d.deletions)
+        try {
+          val commitGraphs = git.log.all.call.iterator.asScala.map { rev =>
+            val p = Process.apply(
+              Seq(loadCommitGraphsSettings().CommitGraphsGitCommand, "log", "-n", "1",
+                "--numstat", """--pretty="%H"""", "--source", rev.getId.name), 
+              git.getRepository.getDirectory)
+            val (additions, deletions) = 
+              p.lineStream_!.filter(_.split("\t").length == 3).foldLeft((0, 0)) { (i, l) =>
+                val Array(a, d, filename) = l.split("\t")
+                a.forall(_.isDigit) && d.forall(_.isDigit) match {
+                  case true => (i._1 + a.toInt, i._2 + d.toInt)
+                  case _    => i
                 }
-                val dh = ds.head
-                DailyCount(
-                  userName = dh.commit.authorName,
-                  mailAddress = dh.commit.authorEmailAddress,
-                  date = dateStr2Date(date),
-                  commits = ds.length,
-                  additions = additions,
-                  deletions = deletions)
-            }.toSeq.sortWith((lt1, lt2) => lt1.date.compareTo(lt2.date) < 0)
-
-            val (additions, deletions) = dailys.foldLeft((0L, 0L)) { (i, d) =>
-              (i._1 + d.additions, i._2 + d.deletions)
-            }
-            CommitGraph(
-              userName = userName,
-              mailAddress = mailAddress,
-              commits = ds.length,
+              }
+            CommitCount(
+              commit = new CommitInfo(rev),
               additions = additions,
-              deletions = deletions,
-              dailys = dailys)
-        }
+              deletions = deletions)
+          }.toSeq.groupBy { x =>
+            if (x.commit.isDifferentFromAuthor) (x.commit.committerName, x.commit.committerEmailAddress)
+            else (x.commit.authorName, x.commit.authorEmailAddress)
+          }.toSeq.sortWith((lt1, lt2) => lt1._2.lengthCompare(lt2._2.length) > 0).map {
+            case ((userName, mailAddress), ds) =>
+              val dailys = ds.groupBy(x => date2DateStr(x.commit.authorTime)).map {
+                case (date, ds) =>
+                  val (additions, deletions) = ds.foldLeft((0L, 0L)) { (i, d) =>
+                    (i._1 + d.additions, i._2 + d.deletions)
+                  }
+                  val dh = ds.head
+                  DailyCount(
+                    userName = dh.commit.authorName,
+                    mailAddress = dh.commit.authorEmailAddress,
+                    date = dateStr2Date(date),
+                    commits = ds.length,
+                    additions = additions,
+                    deletions = deletions)
+              }.toSeq.sortWith((lt1, lt2) => lt1.date.compareTo(lt2.date) < 0)
 
-        html.list(repository, commitGraphs)
+              val (additions, deletions) = dailys.foldLeft((0L, 0L)) { (i, d) =>
+                (i._1 + d.additions, i._2 + d.deletions)
+              }
+              CommitGraph(
+                userName = userName,
+                mailAddress = mailAddress,
+                commits = ds.length,
+                additions = additions,
+                deletions = deletions,
+                dailys = dailys)
+          }
+          html.list(repository, commitGraphs)
+        } catch {
+          case _ : Throwable =>
+            html.error(repository)
+        }
       }
     }
   })
+
+  private def checkGitCommand(command: String): Boolean = {
+    try{ 
+      val processBuilder = Process.apply(command)
+      if( processBuilder.!(ProcessLogger(line => ())) == 1 ) true else false
+    } catch {
+      case _ : Throwable => false
+    }
+  }
 
   private def date2DateStr(date: java.util.Date): String = new java.text.SimpleDateFormat("yyyy-MM-dd").format(date)
   private def dateStr2Date(date: String): java.util.Date = new java.text.SimpleDateFormat("yyyy-MM-dd").parse(date)

--- a/src/main/scala/me/huzi/gitbucket/commitgraphs/service/CommitGraphsSettingsService.scala
+++ b/src/main/scala/me/huzi/gitbucket/commitgraphs/service/CommitGraphsSettingsService.scala
@@ -1,0 +1,65 @@
+package me.huzi.gitbucket.commitgraphs.service
+
+import java.io.File
+
+import gitbucket.core.util.Directory._
+import gitbucket.core.util.SyntaxSugars._
+import me.huzi.gitbucket.commitgraphs.service.CommitGraphsSettingsService._
+
+trait CommitGraphsSettingsService {
+
+  val CommitGraphsConf = new File(GitBucketHome, "commitgraphs.conf")
+
+  def saveCommitGraphsSettings(settings: CommitGraphsSettings): Unit =
+    defining(new java.util.Properties()) { props =>
+      props.setProperty(CommitGraphsGitCommand, settings.CommitGraphsGitCommand)
+      using(new java.io.FileOutputStream(CommitGraphsConf)) { out =>
+        props.store(out, null)
+      }
+    }
+
+  def loadCommitGraphsSettings(): CommitGraphsSettings =
+    defining(new java.util.Properties()) { props =>
+      if (CommitGraphsConf.exists) {
+        using(new java.io.FileInputStream(CommitGraphsConf)) { in =>
+          props.load(in)
+        }
+      }
+      CommitGraphsSettings(
+        getValue[String](props, CommitGraphsGitCommand, "git"),
+        "check"
+      )
+    }
+}
+
+object CommitGraphsSettingsService {
+  import scala.reflect.ClassTag
+
+  case class CommitGraphsSettings(CommitGraphsGitCommand: String,action: String)
+
+  private val CommitGraphsGitCommand = "CommitGraphsGitCommand"
+  private val action = "action"
+
+  private def getValue[A: ClassTag](props: java.util.Properties,
+                                    key: String,
+                                    default: A): A =
+    defining(props.getProperty(key)) { value =>
+      if (value == null || value.isEmpty) default
+      else convertType(value).asInstanceOf[A]
+    }
+
+  private def getOptionValue[A: ClassTag](props: java.util.Properties,
+                                          key: String,
+                                          default: Option[A]): Option[A] =
+    defining(props.getProperty(key)) { value =>
+      if (value == null || value.isEmpty) default
+      else Some(convertType(value)).asInstanceOf[Option[A]]
+    }
+
+  private def convertType[A: ClassTag](value: String) =
+    defining(implicitly[ClassTag[A]].runtimeClass) { c =>
+      if (c == classOf[Boolean]) value.toBoolean
+      else if (c == classOf[Int]) value.toInt
+      else value
+    }
+}

--- a/src/main/twirl/me/huzi/gitbucket/commitgraphs/error.scala.html
+++ b/src/main/twirl/me/huzi/gitbucket/commitgraphs/error.scala.html
@@ -3,7 +3,7 @@
 @import gitbucket.core.view.helpers._
 @gitbucket.core.html.main("Commit Graphs", Some(repository)) {
   @gitbucket.core.html.menu("commitgraphs", repository){
-    <h3>This is an empty repository</h3>
+    <strong>Error occurred. Check git command setting.</strong>
   }
 }
 

--- a/src/main/twirl/me/huzi/gitbucket/commitgraphs/list.scala.html
+++ b/src/main/twirl/me/huzi/gitbucket/commitgraphs/list.scala.html
@@ -3,7 +3,7 @@
 @import context._
 @import gitbucket.core.view.helpers._
 @gitbucket.core.html.main("Commit Graphs", Some(repository)){
-  @gitbucket.core.html.menu("graphs", repository){
+  @gitbucket.core.html.menu("commitgraphs", repository){
 
     <script src="https://www.google.com/jsapi"></script>
     <script> google.load("visualization", "1", {packages:["corechart"]}); </script>

--- a/src/main/twirl/me/huzi/gitbucket/commitgraphs/settings.scala.html
+++ b/src/main/twirl/me/huzi/gitbucket/commitgraphs/settings.scala.html
@@ -1,0 +1,29 @@
+@(commitGraphsGitCommand: String, info: Option[Any])(implicit context: gitbucket.core.controller.Context)
+@import context._
+@import gitbucket.core.html.main
+@import gitbucket.core.admin.html.menu
+@import gitbucket.core.helper.html.information
+@import gitbucket.core.view.helpers._
+@import gitbucket.core.util.Directory._
+@main("Commit Graph"){
+@menu("Commit Graph"){
+@information(info)
+<form action="@path/admin/commitgraphs" method="POST" validate="true">
+    <div class="panel panel-default">
+        <div class="panel-heading strong">Commit Graph Settings</div>
+        <div class="panel-body">
+            <fieldset>
+                <label><span class="strong">Git Command</span></label>
+                <input type="text" style="width: 635px;" name="commitGraphsGitCommand" value="@commitGraphsGitCommand"/>
+                <p class="muted">e.g. git, /usr/bin/git, c:/cygwin/bin/git.exe</p>                
+            </fieldset>
+        </div>
+    </div>
+    <fieldset>
+        <input type="hidden" name="action" id="action" value="apply"/>
+        <input type="submit" class="btn btn-success" value="Apply changes"/>
+        <input type="submit" class="btn" value="Check git command" onClick="$('#action').val('check')"/>
+    </fieldset>
+</form>
+}
+}


### PR DESCRIPTION
This enables this plugin runs when no git command in the path.
Especially with windows, git is not always in their path.
So by setting absolute path(e.g. /usr/bin/git, c:/cygwin/bin/git), enables plugin works correctly.
(without modification to plugin source and rebuild it!)

And when Process() throwing exception, shows error page.
I believe it suppresses "raw java exception" that annoys a user and an administrator.

This patch also includes, when selecting "Commit Graphs" menu in repo, activating that menu correctly.