### PR TITLE
Bump to Scalatra 2.6 & Scala 2.12.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ lazy val root = (project in file(".")).enablePlugins(SbtTwirl)
 organization := Organization
 name := ProjectName
 version := ProjectVersion
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.4"
 
 libraryDependencies ++= Seq(
-  "io.github.gitbucket" %% "gitbucket"          % "4.12.1" % "provided",
+  "io.github.gitbucket" %% "gitbucket"          % "4.19.0"  % "provided",
   "com.typesafe.play"   %% "twirl-compiler"     % "1.3.0"  % "provided",
   "javax.servlet"        % "javax.servlet-api"  % "3.1.0"  % "provided"
 )

--- a/src/main/scala/me/huzi/gitbucket/commitgraphs/controller/CommitGraphsController.scala
+++ b/src/main/scala/me/huzi/gitbucket/commitgraphs/controller/CommitGraphsController.scala
@@ -10,7 +10,7 @@ import gitbucket.core.util.AdminAuthenticator
 import gitbucket.core.util.SyntaxSugars._
 import gitbucket.core.util.Directory._
 import gitbucket.core.util.JGitUtil._
-import io.github.gitbucket.scalatra.forms._
+import org.scalatra.forms._
 import me.huzi.gitbucket.commitgraphs.service.CommitGraphsSettingsService
 import me.huzi.gitbucket.commitgraphs.service.CommitGraphsSettingsService._
 import me.huzi.gitbucket.commitgraphs.html


### PR DESCRIPTION
fix GitBucket 4.19.0

> Caused by: java.lang.ClassNotFoundException: io.github.gitbucket.scalatra.forms.package$ValueType
>         at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
>         at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
>         at java.lang.ClassLoader.loadClass(ClassLoader.java:357)

see https://github.com/gitbucket/gitbucket-pages-plugin/pull/23